### PR TITLE
Alex misc fixes

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -19,6 +19,8 @@ class DataValidationError(Exception):
     pass
 
 
+VALID_TYPES = ["BUY_ONE_GET_ONE", "PERCENT_DISCOUNT", "FREE_SHIPPING", "VIP"]
+
 class PromoType(Enum):
     """Enumeration of valid Promotion types"""
 
@@ -104,7 +106,11 @@ class Promotion(db.Model):
         try:
             self.name = data["name"]
             # create enum from string
-            self.type = getattr(PromoType, data["type"])
+
+            if (data["type"] in VALID_TYPES):
+                self.type = getattr(PromoType, data["type"])
+            else:
+                raise TypeError
             self.discount = data["discount"]
             self.customer = data["customer"]
             self.start_date = data["start_date"]

--- a/service/routes.py
+++ b/service/routes.py
@@ -29,7 +29,11 @@ CONTENT_TYPE_JSON = "application/json"
 def index():
     """ Root URL response """
     return (
-        "Reminder: return some useful information in json format about the service here",
+        jsonify(
+            name="Promotion REST API Service",
+            version="1.0",
+            paths=url_for("list_promos", _external=True),
+        ),
         status.HTTP_200_OK,
     )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -164,3 +164,25 @@ class TestPromotionModel(unittest.TestCase):
         print(f"Created a promotion, id = {promo.id}")
         inserted_promo = Promotion.find(id)
         self.assertIsNotNone(inserted_promo)
+
+    def test_find_promotion_by_name(self):
+        """It should find a promotion by name"""
+        promo = PromoFactory()
+        promo.name = "foo"
+        promo.create()
+        db.session.refresh(promo)
+        name = promo.name
+        print(f"Created a promotion, name = {name}")
+        inserted_promo = Promotion.find_by_name(name)
+        self.assertIsNotNone(inserted_promo)
+
+    def test_find_promotion_by_type(self):
+        """It should find a promotion by type"""
+        promo = PromoFactory()
+        promo.name = "foo"
+        promo.create()
+        db.session.refresh(promo)
+        type = promo.type.name
+        print(f"Created a promotion, name = {type}")
+        inserted_promo = Promotion.find_by_type(type)
+        self.assertIsNotNone(inserted_promo)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -174,6 +174,23 @@ class TestPromotionServer(TestCase):
             content_type=CONTENT_TYPE_JSON
         )
 
+    def test_create_promo_bad_duplicate(self):
+        """It should not create a duplicate Promotion"""
+        test_promo = PromoFactory()
+        test_promo.name = "foo"
+        response_1 = self.client.post(
+            BASE_URL,
+            json=test_promo.serialize(),
+            content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
+        response_2 = self.client.post(
+            BASE_URL,
+            json=test_promo.serialize(),
+            content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(response_2.status_code, status.HTTP_409_CONFLICT)
+
     def test_bad_content_type(self):
         """It should correctly detect a bad content type"""
         non_json = "text/html"


### PR DESCRIPTION
A few quick fixes:
- test coverage for get_by_X() Promotion lookups
- handling for bad Enums as noticed by Daming
- adds information at the index route per instructions
- handler + test coverage for 409 responses when creating a duplicate Promotion (where "duplicate" means "same name and type", currently)

With this, we should have 96% test coverage per what I am seeing.