### PR TITLE
add cli commands for DB (re)creation + corresponding tests

### DIFF
--- a/service/__init__.py
+++ b/service/__init__.py
@@ -16,6 +16,7 @@ app.config.from_object("config")
 # Dependencies require we import the routes AFTER the Flask app is created
 from service import routes, models # pylint: disable=wrong-import-position, wrong-import-order
 from .utils import error_handlers  # pylint: disable=wrong-import-position
+from .utils import cli_commands  # noqa: F401, E402
 
 # Set up logging for production
 log_handlers.init_logging(app, "gunicorn.error")

--- a/service/utils/cli_commands.py
+++ b/service/utils/cli_commands.py
@@ -1,0 +1,20 @@
+"""
+Flask CLI Command Extensions
+"""
+from service import app
+from service.models import db
+
+
+######################################################################
+# Command to force tables to be rebuilt
+# Usage: flask create-db
+######################################################################
+@app.cli.command("create-db")
+def create_db():
+    """
+    Recreates a local database. You probably should not use this on
+    production.
+    """
+    db.drop_all()
+    db.create_all()
+    db.session.commit()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+from service.utils.cli_commands import create_db
+
+
+class TestFlaskCLI(TestCase):
+    """Test Flask CLI Commands"""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('service.utils.cli_commands.db')
+    def test_create_db(self, db_mock):
+        """It should call the create-db command"""
+        db_mock.return_value = MagicMock()
+        result = self.runner.invoke(create_db)
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
This PR adds the CLI tools from Professor Rofrano in the form of a `flask` command to enable quick reset of the database (e.g. if we want to change the model)