### PR TITLE
Cancel promotion early

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -69,6 +69,8 @@ def create_promo():
 ######################################################################
 # FIND A PROMOTION BY ID
 ######################################################################
+
+
 @app.route("/promotions/<promo_id>", methods=["GET"])
 def find_promo(promo_id):
     """
@@ -103,8 +105,10 @@ def find_promo(promo_id):
 
 
 ######################################################################
-# DELETE A PROMO
+# DELETE A PROMOTION
 ######################################################################
+
+
 @app.route("/promotions/<promo_id>", methods=["DELETE"])
 def delete_promo(promo_id):
     """
@@ -122,8 +126,10 @@ def delete_promo(promo_id):
     return "", status.HTTP_204_NO_CONTENT
 
 ######################################################################
-# LIST ALL PROMO
+# LIST ALL PROMOTIONS
 ######################################################################
+
+
 @app.route("/promotions", methods=["GET"])
 def list_promos():
     """Returns all of the Promos"""
@@ -142,9 +148,12 @@ def list_promos():
     app.logger.info("Returning %d promotions", len(results))
     return jsonify(results), status.HTTP_200_OK
 
+
 ######################################################################
 # UPDATE AN EXISTING PROMOTION
 ######################################################################
+
+
 @app.route("/promotions/<promo_id>", methods=["PUT"])
 def update_promotions(promo_id):
     """
@@ -165,6 +174,32 @@ def update_promotions(promo_id):
 
     app.logger.info("Promotion with ID [%s] updated.", promotion.id)
     return jsonify(promotion.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# EARLY CANCEL AN EXISTING PROMOTION
+######################################################################
+
+
+@app.route("/promotions/<promo_id>/cancel", methods=["PUT"])
+def early_cancel_promotion(promo_id):
+    """
+    Cancel a Promotion early
+
+    This endpoint will set the end date of Promotion with ID `promo_id` to its start date.
+    A Promotion with equal start and end dates is semantically considered canceled.
+    """
+    app.logger.info("Request to cancel a Promotion with id: %s", promo_id)
+    # attempt to locate Promotion for early cancellation
+    promotion = Promotion.find(promo_id)
+    if not promotion:
+        abort(status.HTTP_404_NOT_FOUND, f"Promotion with id '{promo_id}' was not found.")
+    # set the information
+    promotion.end_date = promotion.start_date
+    promotion.update()
+    app.logger.info("Promotion with ID [%s] has been canceled.", promotion.id)
+    return jsonify(promotion.serialize()), status.HTTP_200_OK
+
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -205,7 +205,7 @@ class TestPromotionServer(TestCase):
                          status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     def test_find_promo_by_id(self):
-        """It should create a Promotion and find it by id"""
+        """It should create a Promotion and find it by ID"""
         test_promo = PromoFactory()
         response = self.client.post(
             BASE_URL,
@@ -225,7 +225,7 @@ class TestPromotionServer(TestCase):
         self.assertEqual(new_promo_1["id"], id)
 
     def test_find_promo_by_id_not_found(self):
-        """It should not find a promotion that doesn't exist"""
+        """It should not find a Promotion that does not exist"""
         promotions = Promotion.all()
         self.assertEqual(promotions, [])
 
@@ -236,7 +236,7 @@ class TestPromotionServer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_find_promo_by_id_post(self):
-        """It should not find a promotion with post method"""
+        """It should not find a Promotion via an HTTP POST method"""
         response = self.client.post(
             BASE_URL + '/' + '1',
         )
@@ -244,7 +244,7 @@ class TestPromotionServer(TestCase):
                          status.HTTP_405_METHOD_NOT_ALLOWED)
     
     def test_find_promo_by_id_not_a_number(self):
-        """It should not find a promotion with a non-number id"""
+        """It should not find a Promotion with a non-numeric ID"""
         response = self.client.get(
             BASE_URL + '/' + 'a',
         )
@@ -252,7 +252,7 @@ class TestPromotionServer(TestCase):
                          status.HTTP_400_BAD_REQUEST)
 
     def test_find_promo_by_id_out_of_range(self):
-        """It should not find a promotion with a number out of range"""
+        """It should not find a Promotion with an ID number out of range"""
         response = self.client.get(
             BASE_URL + '/' + '2147483648',
         )
@@ -260,7 +260,7 @@ class TestPromotionServer(TestCase):
                          status.HTTP_400_BAD_REQUEST)
         
     def test_update_promotion(self):
-        """It should Update an existing Promotion"""
+        """It should update an existing Promotion"""
         # create a promotion to update
         test_promo = PromoFactory()
         response = self.client.post(BASE_URL, json=test_promo.serialize())
@@ -277,7 +277,7 @@ class TestPromotionServer(TestCase):
         self.assertEqual(updated_promo["name"], "GOOD")
         
     def test_update_promotion_not_exists(self):
-        """It should not update a Promotion not exist"""
+        """It should not update a Promotion that does not exist"""
         # create a promotion to update
         test_promo = PromoFactory()
         response = self.client.post(BASE_URL, json=test_promo.serialize())

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -290,3 +290,28 @@ class TestPromotionServer(TestCase):
         new_promo["name"] = "GOOD"
         response = self.client.put(BASE_URL + '/' + str(id), json=new_promo)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cancel_promotion(self):
+        """It should early cancel a Promotion that exists by setting end_date equal to start_date"""
+        # create a Promotion to cancel
+        test_promo = PromoFactory()
+        response_1 = self.client.post(BASE_URL, json=test_promo.serialize())
+        new_promo = response_1.get_json()
+        self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
+        # cancel the Promotion that was just created
+        promo_id = new_promo["id"]
+        response_2 = self.client.put(BASE_URL + '/' + str(promo_id) + "/cancel")
+        updated_promo = response_2.get_json()
+        self.assertEqual(response_2.status_code, status.HTTP_200_OK)
+        self.assertEqual(updated_promo["start_date"], updated_promo["end_date"])
+
+    def test_cancel_promotion_not_exists(self):
+        """It should not early cancel a Promotion that does not exist"""
+        # create a Promotion to generate the highest current ID
+        test_promo = PromoFactory()
+        response_1 = self.client.post(BASE_URL, json=test_promo.serialize())
+        new_promo = response_1.get_json()
+        self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
+        bad_id = new_promo["id"] + 1
+        response_2 = self.client.put(BASE_URL + '/' + str(bad_id) + "/cancel")
+        self.assertEqual(response_2.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Addresses functionality in user story https://github.com/devops-summer22-promotions/promotions/issues/32 per description in that issue (using the semantics of setting `end_date` to `start_date` in order to early cancel a Promotion).