### PR TITLE
Add IBM Cloud tools to development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Image for a Python 3 development environment
 FROM python:3.9-slim
 
-# Add any tools that are needed beyond Python 3
+# Add any tools that are needed beyond Python 3.9
 RUN apt-get update && \
     apt-get install -y sudo vim make git zip tree curl wget jq && \
     apt-get autoremove -y && \
@@ -19,17 +19,23 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Added libraries for PostgreSQL
+# Added libraries for PostgreSQL before pip install
 RUN apt-get install -y gcc libpq-dev
 
 # Set up the Python development environment
 WORKDIR /app
-RUN python -m pip install --upgrade pip wheel
+RUN python -m pip install --upgrade pip && \
+    pip install --upgrade wheel
 
-EXPOSE 8000
+ENV PORT 8080
+EXPOSE $PORT
 
 # Enable color terminal for docker exec bash
 ENV TERM=xterm-256color
 
-# Become a regular user
+# Become a regular user for development
 USER $USERNAME
+
+# Install user mode tools
+COPY .devcontainer/scripts/install-tools.sh /tmp/
+RUN cd /tmp; bash ./install-tools.sh

--- a/.devcontainer/scripts/install-tools.sh
+++ b/.devcontainer/scripts/install-tools.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+######################################################################
+# These scripts are meant to be run in user mode as they modify
+# usr settings line .bashrc and .bash_aliases
+######################################################################
+
+echo "**********************************************************************"
+echo "Installing K3D Kubernetes..."
+echo "**********************************************************************"
+curl -s "https://raw.githubusercontent.com/rancher/k3d/main/install.sh" | sudo bash
+
+echo "**********************************************************************"
+echo "Installing IBM Cloud CLI..."
+echo "**********************************************************************"
+curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+echo "source /usr/local/ibmcloud/autocomplete/bash_autocomplete" >> $HOME/.bashrc
+# Install user mode tools
+ibmcloud plugin install container-service -r 'IBM Cloud'
+ibmcloud plugin install container-registry -r 'IBM Cloud'
+
+echo "Creating aliases for new tools..."
+echo "alias ic='/usr/local/bin/ibmcloud'" >> $HOME/.bash_aliases
+echo "alias kc='/usr/local/bin/kubectl'" >> $HOME/.bash_aliases
+echo "alias ku='/usr/local/bin/kustomize'" >> $HOME/.bash_aliases
+echo "alias kns='kubectl config set-context --current --namespace'" >> $HOME/.bash_aliases
+
+# Platform specific installs
+if [ $(uname -m) == aarch64 ]; then
+    echo "Installing YQ for ARM64..."
+    sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_arm64
+    sudo chmod a+x /usr/local/bin/yq
+else
+    echo "Installing YQ for x86_64..."
+    sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    sudo chmod a+x /usr/local/bin/yq
+fi;


### PR DESCRIPTION
Uses new `install-tools.sh` script to add tools via the `Dockerfile`; we now have access to the `ibmcloud` command inside the development container.